### PR TITLE
김유정/Home/Home JS-뷰 전환한 부분, 그리드 뷰 제목 시작점 맞춤, 리스트 뷰 항목 수정

### DIFF
--- a/Home CSS.css
+++ b/Home CSS.css
@@ -21,7 +21,13 @@
   --size_write-info : 12px;
   /* size(Home의 list view) */
   --size_list-view : 14px;
-
+  --size_list-view-content : 13px;
+  
+  /* width&height */
+  --width_list-view-content-title : 360px;
+  --width_list-view-book-title : 190px;
+  --width_list-view-profile-nickname : 130px;
+  --height_list-view-content : 80px;
 
   /*color*/
   --color_highlight : #4FBA80; /*버튼, 하이라이트된 부분*/
@@ -38,6 +44,8 @@
 
   /*padding*/
   --padding_container-top: 30px;
+  --padding_list-view-content: 10px;
+  --padding_lsit-view-content-right: 15px;
   
   /*margin*/
   --margin_container-side : 80px;
@@ -425,12 +433,12 @@ header nav #write-button {
   flex-wrap: wrap;
   grid-template-columns: repeat(auto-fill, minmax(270px, 300px));
   grid-template-rows: repeat(auto-fill, minmax(220px, auto));
-  gap: 24px;
+  gap: 21px;
 } 
 
 #grid-view .grid-view-content {
   position: relative;
-  width: 270px;
+  width: 286px;
   background-color: var(--color_white);
   border: 1px solid rgb(0, 0, 0, 0.87);
 }
@@ -462,10 +470,11 @@ header nav #write-button {
 }
 
 #grid-view .grid-view-content .grid-book-info {
-  padding: 15px 20px;
+  padding: 5px 15px;
 }
 
 #grid-view .grid-view-content .grid-book-info .grid-content-title {
+  height: 42px;
   font-size: var(--size_grid-content-title);
 }
 
@@ -478,7 +487,7 @@ header nav #write-button {
 }
 
 #grid-view .grid-view-content .write-info {
-  position: absolute;
+  position: relative;
   bottom: 0;
   display: flex;
   flex-direction: row;
@@ -490,9 +499,6 @@ header nav #write-button {
   font-size: var(--size_write-info);
 }
 
-#grid-view .grid-view-content .write-info .profile-nickname {
-  
-}
 
 /* list-view */
 #list-view {
@@ -513,19 +519,38 @@ header nav #write-button {
   font-size: var(--size_list-view);
 }
 
-#list-view .classification .classification-book-type {
-  width: 120px;
-}
-
 #list-view .classification .classification-content-title {
-  width: 400px;
+  width: var(--width_list-view-content-title);
 }
 
 #list-view .classification .classification-book-title {
-  width: 140px;
+  width: var(--width_list-view-book-title);
+}
+
+#list-view .classification .classification-profile-nickname {
+  width: var(--width_list-view-profile-nickname);
 }
 
 #list-view .list-view-content {
-  height: 46px;
+  display: flex;
+  align-items: center;
+  height: var(--height_list-view-content);
   border-bottom: 1px solid rgb(0, 0, 0, 0.08);
+  padding: var(--padding_list-view-content);
+  font-size: var(--size_list-view-content);
+}
+
+#list-view .list-view-content .list-content-title {
+  width: var(--width_list-view-content-title);
+  padding-right: var(--padding_lsit-view-content-right);
+}
+
+#list-view .list-view-content .list-book-title {
+  width: var(--width_list-view-book-title);
+  padding-right: var(--padding_lsit-view-content-right);
+}
+
+#list-view .list-view-content .list-profile-nickname {
+  width: var(--width_list-view-profile-nickname);
+  padding-right: var(--padding_lsit-view-content-right);
 }

--- a/Home CSS.css
+++ b/Home CSS.css
@@ -8,12 +8,19 @@
   --size_menu : 20px; /*Home - 책 찾아보기, 필터, 트렌딩, 책 제목 / Write & Detail - 서명, 분야, 저자, 출판사 / Sign up - 회원가입 */
   --size_comments : 16px; /*댓글*/
   --size_hashtag : 16px; /*해시태그#*/
-  --size-menu-medium : 14px;
+  --size_menu-medium : 14px;
   --size_button : 14px; /*모든 버튼*/
   --size_list : 14px; /*Home - 리스트에 들어가는 모든 항목(분야, 제목, 저자, 작성자, 좋아요)*/
   --size_profile : 14px; /*프로필 - 이름, 작성된 날짜*/
   --size_signup-input : 12px; /*Sign up - input박스 안에 들어가는 입력값, 개인정보 동의 안내*/
-
+  /*size(Home의 grid view)*/
+  --size_grid-content-title : 18px;
+  --size_like-number :12px;
+  --size_grid-book-title : 12px;
+  --size_summary : 14px;
+  --size_write-info : 12px;
+  /* size(Home의 list view) */
+  --size_list-view : 14px;
 
 
   /*color*/
@@ -33,7 +40,7 @@
   --padding_container-top: 30px;
   
   /*margin*/
-  --margin_container-side : 100px;
+  --margin_container-side : 80px;
 }
 
 * {
@@ -43,6 +50,14 @@
 button {
   border-style: none;
   background: none;
+}
+
+button:focus {
+  border: none;
+  outline: none;
+}
+input:focus {
+  outline: none;
 }
 
 a {
@@ -57,7 +72,7 @@ html {
 body {
   position: relative;
   margin: 0;
-  background: linear-gradient(var(--color_gradient), 40px, var(--color_background) 100px, var(--color_background));
+  background: linear-gradient(var(--color_gradient), 40px, var(--color_background) 100px) var(--color_gradient);
 }
 
 body.login-form-show::after {
@@ -72,10 +87,11 @@ body.login-form-show::after {
 
 .container {
   display: grid;
+  grid-template-columns: 300px 1fr;
   grid-template-rows: 85px 85px 1fr;
   padding-top: var(--padding_container-top);
   margin: 0 var(--margin_container-side);
-  column-gap: 100px;
+  column-gap: 80px;
 }
 
 header {
@@ -108,6 +124,7 @@ header nav .sign-up {
   padding: 7px 6px 1px 6px;
 }
 
+/* login-form 관련 css */
 header #login-form-container {
   display: none;
   position: absolute;
@@ -117,7 +134,6 @@ header #login-form-container {
   height: 100vh;
 }
 
-/* login-form 관련 css */
 header #login-form-container .login-form {
   display: flex;
   flex-direction: column;
@@ -161,6 +177,7 @@ header #login-form-container .login-form .login-form-hide:hover {
 header #login-form-container .login-form input {
   height: 40px;
   border: 1px solid rgb(0, 0, 0, 0.08);
+  padding: 10px;
   margin: 10px 0 20px 0;
   background-color: rgb(0, 0, 0, 0.03);
 }
@@ -240,40 +257,41 @@ header nav #write-button {
   margin-top: 27px;
 }
 
-#searching-menu {
+#category #searching-menu {
   display: flex;
   align-items: center;
   height: 27px;
 }
 
-#searching-menu img{
+#category #searching-menu img{
   width: 24px;
   height: 24px;
   padding: 3px;
 }
 
-.searching-input {
+#category #searching-menu .search {
+  font-size: var(--size_menu);
+}
+
+#category .searching-input {
   display: flex;
   justify-content: space-between;
   align-items: center;
   height: 40px;
   border: 1px solid var(--color_black);
-  padding: 16px;
+  padding: 8px;
   margin-top: 15px;
   background-color: var(--color_white);
 }
 
-#searching {
+#category .searching-input #searching {
   width: 100%;
   border: none;
   background-color: var(--color_white);
 }
 
-#searching-menu .search {
-  font-size: var(--size_menu);
-}
 
-#filter-menu {
+#category #filter-menu {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -283,23 +301,23 @@ header nav #write-button {
   margin-top: 37px;
 }
 
-#filter-menu img {
+#category #filter-menu img {
   width: 24px;
   height: 24px;
   padding: 3px;
 }
 
-#filter-menu .filter {
+#category #filter-menu .filter {
   font-size: var(--size_menu);
 }
 
 #category .category-menu {
   display: block;
   margin: 15px 0px;
-  font-size: var(--size-menu-medium);
+  font-size: var(--size_menu-medium);
 }
 
-.book-from {
+#category .book-from {
   display: flex;
   justify-content: flex-start;
   padding-bottom: 20px;
@@ -307,22 +325,19 @@ header nav #write-button {
   font-size: var(--size_button);
 }
 
-.book-from .domestic {
+#category .book-from button {
   width: 95px;
-  padding: 11px 10px;
   border: 1px solid var(--color_black);
-  margin-right: 9px;
+  padding: 11px 10px;
+  margin-right: 7.5px;
   background-color: var(--color_white);
 }
 
-.book-from .overseas {
-  width: 95px;
-  padding: 11px 10px;
-  border: 1px solid var(--color_black);
-  background-color: var(--color_white);
+#category .book-from button:hover {
+  background-color: rgb(0, 0, 0, 0.08);
 }
 
-.book-type {
+#category .book-type {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -330,7 +345,7 @@ header nav #write-button {
   font-size: var(--size_button);
 }
 
-.book-type .field {
+#category .book-type .field {
   width: 95px;
   border: solid 1px var(--color_black);
   padding: 11px 10px;
@@ -338,14 +353,22 @@ header nav #write-button {
   background-color: var(--color_white);
 }
 
-.category-action {
+#category .book-type .field:hover {
+  background-color: rgb(0, 0, 0, 0.08);
+}
+
+#category .book-type .field-selected{
+  background-color: var(--color_highlight);
+}
+
+#category .category-action {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   margin-top: 32px;
 }
 
-.category-action .filter-search {
+#category .category-action .filter-search {
   width: 222px;
   height: 40px;
   color: var(--color_white);
@@ -353,7 +376,7 @@ header nav #write-button {
   background-color: var(--color_highlight);
 }
 
-.category-action .initialize {
+#category .category-action .initialize {
   width: 72px;
   height: 40px;
   border: 1px solid var(--color_black);
@@ -393,29 +416,116 @@ header nav #write-button {
 }
 
 .main {
-  grid-column: 2 / 3;
-  grid-row: 3 / 4;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, auto));
+}
+
+/* grid-view */
+
+#grid-view {
+  display: none;
+  flex-wrap: wrap;
+  grid-template-columns: repeat(auto-fill, minmax(270px, 300px));
   grid-template-rows: repeat(auto-fill, minmax(220px, auto));
   gap: 24px;
-}
-
-.grid-view-contents { 
-  align-items:center;
-  background-color: rgb(217, 228, 225);
 } 
 
-
-.grid-view-contents img {
-  width: 20%;
-  height: auto;
+#grid-view .grid-view-content {
+  position: relative;
+  width: 270px;
+  background-color: var(--color_white);
+  border: 1px solid rgb(0, 0, 0, 0.87);
 }
-.grid-view-content,
-.book-content {
+
+#grid-view .grid-view-content .grid-view-content-img {
+  width: 100%;
+  height: 150px;
+  overflow: hidden;
+  background-color: rgb(0, 0, 0, 0.08);
+  text-align: center;
+}
+
+#grid-view .grid-view-content .grid-view-content-like {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  top: 118px;
+  right: 10px;
+}
+
+#grid-view .grid-view-content .grid-view-content-like img {
+  width: 20px;
+  height: 20px;
+}
+
+#grid-view .grid-view-content .grid-view-content-like .like-number {
+  color: var(--color_white);
+  font-size: var(--size_like-number);
+}
+
+#grid-view .grid-view-content .grid-book-info {
+  padding: 15px 20px;
+}
+
+#grid-view .grid-view-content .grid-book-info .grid-content-title {
+  font-size: var(--size_grid-content-title);
+}
+
+#grid-view .grid-view-content .grid-book-info .grid-book-title {
+  font-size: var(--size_grid-book-title);
+}
+
+#grid-view .grid-view-content .grid-book-info .summary {
+  font-size: var(--size_summary);
+}
+
+#grid-view .grid-view-content .write-info {
+  position: absolute;
+  bottom: 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  height: 45px;
+  border-top: 1px solid rgb(0, 0, 0, 0.08);
+  padding: 10px 15px;
+  font-size: var(--size_write-info);
+}
+
+#grid-view .grid-view-content .write-info .profile-nickname {
+  
+}
+
+/* list-view */
+#list-view {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items:center;
+
 }
 
+#list-view .classification {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  height: 46px;
+  border-top: 1px solid var(--color_black);
+  border-bottom: 1px solid var(--color_black);
+  padding: 10px;
+  font-size: var(--size_list-view);
+}
+
+#list-view .classification .classification-book-type {
+  width: 120px;
+}
+
+#list-view .classification .classification-content-title {
+  width: 400px;
+}
+
+#list-view .classification .classification-book-title {
+  width: 140px;
+}
+
+#list-view .list-view-content {
+  height: 46px;
+  border-bottom: 1px solid rgb(0, 0, 0, 0.08);
+}

--- a/Home JS.js
+++ b/Home JS.js
@@ -11,8 +11,8 @@ let gridViewSelected = document.getElementById("grid-view-selected");
 let listView = document.getElementById("list-view");
 let gridView = document.getElementById("grid-view");
 let indexOfView
-//view 인덱스 변수 선언하기
 
+// 로그인 창 띄우고&닫기
 $(document).ready(function(){
     $(".login").click(function(){
         $("body").toggleClass("login-form-show");
@@ -27,13 +27,30 @@ $(document).ready(function(){
     })
 })
 
+//분야 선택
+function bookTypeSelected(iOfField) {
+    console.log(bookTypeField[iOfField].style.backgroundColor);
+    if (bookTypeField[iOfField].style.backgroundColor == "#FFFFFF") {
+        console.log("하이라이트로 변경");
+        bookTypeField[iOfField].style.backgroundColor = "#4FBA80";
+        bookTypeField[iOfField].style.color = "#FFFFFF";
+    }
+    else{
+        console.log("기본으로 변경");
+        bookTypeField[iOfField].style.backgroundColor = "#FFFFFF";
+        bookTypeField[iOfField].style.color = "#000000";
+    }
+}
+
+// grid view content의 내용 요약
 function contentSummaryPrint() {
     for (let i=0; i<gridContentSummary.length; i++) {
-        console.log(gridContentSummary[i]);
+        console.log(gridContentSummary[i].innerText);
         gridContentSummary[i].innerText = gridContentSummary[i].innerText.slice(0,46) + "...";
     }
 }
 contentSummaryPrint();
 
-listViewSelected.addEventListener("click", function(){listView.style.display = "flex"; gridView.style.display = "none"});
-gridViewSelected.addEventListener("click", function(){listView.style.display = "none"; gridView.style.display = "flex"});
+// view 전환
+listViewSelected.addEventListener("click", function(){listView.style.display = "flex"; gridView.style.display = "none" });
+gridViewSelected.addEventListener("click", function(){listView.style.display = "none"; gridView.style.display = "flex" });

--- a/Home JS.js
+++ b/Home JS.js
@@ -2,6 +2,16 @@
 const body = document.getElementsByTagName("body");
 const loginForm = document.getElementsByClassName("login-form");
 const loginFormContainer = document.getElementById("login-form-container");
+let gridContentSummary = document.getElementsByClassName("summary");
+let bookTypeField = document.getElementsByClassName("field");
+let viewType = document.getElementsByClassName("view-type");
+let viewTypeSelect = document.getElementsByClassName("view-type-select");
+let listViewSelected = document.getElementById("list-view-selected");
+let gridViewSelected = document.getElementById("grid-view-selected");
+let listView = document.getElementById("list-view");
+let gridView = document.getElementById("grid-view");
+let indexOfView
+//view 인덱스 변수 선언하기
 
 $(document).ready(function(){
     $(".login").click(function(){
@@ -16,3 +26,14 @@ $(document).ready(function(){
         $(".login-form").hide();
     })
 })
+
+function contentSummaryPrint() {
+    for (let i=0; i<gridContentSummary.length; i++) {
+        console.log(gridContentSummary[i]);
+        gridContentSummary[i].innerText = gridContentSummary[i].innerText.slice(0,46) + "...";
+    }
+}
+contentSummaryPrint();
+
+listViewSelected.addEventListener("click", function(){listView.style.display = "flex"; gridView.style.display = "none"});
+gridViewSelected.addEventListener("click", function(){listView.style.display = "none"; gridView.style.display = "flex"});

--- a/index.html
+++ b/index.html
@@ -66,21 +66,21 @@
             </div>
             <span class="category-menu">분야</span>
             <div class="book-type">
-                <button class="field" type="button">예술</button>
-                <button class="field" type="button">소설</button>
-                <button class="field" type="button">역사/문화</button>
-                <button class="field" type="button">인문</button>
-                <button class="field" type="button">비문학</button>
-                <button class="field" type="button">경제/경영</button>
-                <button class="field" type="button">정치</button>
-                <button class="field" type="button">영어</button>
-                <button class="field" type="button">과학</button>
-                <button class="field" type="button">여성학</button>
-                <button class="field" type="button">고전</button> 
-                <button class="field" type="button">자기계발</button> 
-                <button class="field" type="button">취미/실용</button> 
-                <button class="field" type="button">컴퓨터</button> 
-                <button class="field" type="button">어린이</button> 
+                <button class="field" type="button" onclick="bookTypeSelected(0)">예술</button>
+                <button class="field" type="button" onclick="bookTypeSelected(1)">소설</button>
+                <button class="field" type="button" onclick="bookTypeSelected(2)">역사/문화</button>
+                <button class="field" type="button" onclick="bookTypeSelected(3)">인문</button>
+                <button class="field" type="button" onclick="bookTypeSelected(4)">비문학</button>
+                <button class="field" type="button" onclick="bookTypeSelected(5)">경제/경영</button>
+                <button class="field" type="button" onclick="bookTypeSelected(6)">정치</button>
+                <button class="field" type="button" onclick="bookTypeSelected(7)">영어</button>
+                <button class="field" type="button" onclick="bookTypeSelected(8)">과학</button>
+                <button class="field" type="button" onclick="bookTypeSelected(9)">여성학</button>
+                <button class="field" type="button" onclick="bookTypeSelected(10)">고전</button> 
+                <button class="field" type="button" onclick="bookTypeSelected(11)">자기계발</button> 
+                <button class="field" type="button" onclick="bookTypeSelected(12)">취미/실용</button> 
+                <button class="field" type="button" onclick="bookTypeSelected(13)">컴퓨터</button> 
+                <button class="field" type="button" onclick="bookTypeSelected(14)">어린이</button> 
                 <!--더 적어야함-->
             </div>
             <div class="category-action">
@@ -116,9 +116,7 @@
                     <div class="grid-book-info">
                         <h1 class="grid-content-title">엔지니어도 인문학이 필요할까?</h1>
                         <h3 class="grid-book-title">엔지니어를 위한 인문학 수업</h3>
-                        <p class="summary">
-                            바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..
-                        </p>
+                        <p class="summary">바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..</p>
                     </div>
                     <div class="write-info">
                         <div class="register-profile"><!--작성자 옆 프로필사진-->
@@ -142,9 +140,7 @@
                     <div class="grid-book-info">
                         <h1 class="grid-content-title">행복은 제 발로 걸어오지 않아. 그러니 내 발로 찾아가야지</h1>
                         <h3 class="grid-book-title">또다시 같은 꿈을 꾸었어</h3>
-                        <p class="summary">
-                            바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..
-                        </p>
+                        <p class="summary">바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..</p>
                     </div>
                     <div class="write-info">
                         <div class="register-profile"><!--작성자 옆 프로필사진-->
@@ -167,9 +163,7 @@
                     <div class="grid-book-info">
                         <h1 class="grid-content-title">엔지니어도 인문학이 필요할까?</h1>
                         <h3 class="grid-book-title">엔지니어를 위한 인문학 수업</h3>
-                        <p class="summary">
-                            바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..
-                        </p>
+                        <p class="summary">바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..</p>
                     </div>
                     <div class="write-info">
                         <div class="register-profile"><!--작성자 옆 프로필사진-->
@@ -193,9 +187,7 @@
                     <div class="grid-book-info">
                         <h1 class="grid-content-title">엔지니어도 인문학이 필요할까?</h1>
                         <h3 class="grid-book-title">엔지니어를 위한 인문학 수업</h3>
-                        <p class="summary">
-                            바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..
-                        </p>
+                        <p class="summary">바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..</p>
                     </div>
                     <div class="write-info">
                         <div class="register-profile"><!--작성자 옆 프로필사진-->
@@ -219,9 +211,7 @@
                     <div class="grid-book-info">
                         <h1 class="grid-content-title">엔지니어도 인문학이 필요할까?</h1>
                         <h3 class="grid-book-title">엔지니어를 위한 인문학 수업</h3>
-                        <p class="summary">
-                            바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..
-                        </p>
+                        <p class="summary">바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..</p>
                     </div>
                     <div class="write-info">
                         <div class="register-profile"><!--작성자 옆 프로필사진-->
@@ -235,14 +225,29 @@
             </div>
             <div id="list-view">
                 <div class="classification">
-                    <div class="classification-book-type">분야</div>
                     <div class="classification-content-title">제목</div>
                     <div class="classification-book-title">책 제목</div>
                     <div class="classification-profile-nickname">작성자</div>
+                    <div class="classification-register-date">작성일</div>
                 </div>
-                <div class="list-view-content"></div>
-                <div class="list-view-content"></div>
-                <div class="list-view-content"></div>
+                <div class="list-view-content">
+                    <div class="list-content-title">엔지니어도 인문학이 필요할까?</div>
+                    <div class="list-book-title">엔지니어를 위한 인문학 수업</div>
+                    <div class="list-profile-nickname">Yunji Jeong</div>
+                    <div class="list-register-date">2021. 02. 02</div>
+                </div>
+                <div class="list-view-content">
+                    <div class="list-content-title">행복은 제 발로 걸어오지 않아. 그러니 내 발로 찾아가야지</div>
+                    <div class="list-book-title">또다시 같은 꿈을 꾸었어</div>
+                    <div class="list-profile-nickname">yujung7768903</div>
+                    <div class="list-register-date">2021. 03. 22</div>
+                </div>
+                <div class="list-view-content">
+                    <div class="list-content-title"></div>
+                    <div class="list-book-title"></div>
+                    <div class="list-profile-nickname"></div>
+                    <div class="list-register-date"></div>
+                </div>
                 <div class="list-view-content"></div>
                 <div class="list-view-content"></div>
                 <div class="list-view-content"></div>

--- a/index.html
+++ b/index.html
@@ -66,8 +66,8 @@
             </div>
             <span class="category-menu">분야</span>
             <div class="book-type">
-                <button class="field" type="button">소설</button>
                 <button class="field" type="button">예술</button>
+                <button class="field" type="button">소설</button>
                 <button class="field" type="button">역사/문화</button>
                 <button class="field" type="button">인문</button>
                 <button class="field" type="button">비문학</button>
@@ -96,130 +96,164 @@
                 <div class="latest">최신</div>
             </div>
             <div class="view-type">
-                <img src="icon/list_black.svg">
-                <img src="icon/grid_black.svg">
+                <button id="list-view-selected" class="view-type-select"><img src="icon/list_black.svg"></button>
+                <button id="grid-view-selected" class="view-type-select"><img src="icon/grid_black.svg"></button>
                 <!--따로 버튼 없이 선택하자마자 적용되는 방법은?-->
             </div>
         </div>
         
         <section class="main">
-            <div class="grid-view-contents">
+            <div id="grid-view">
                 <div class="grid-view-content">
-                    <img src="https://t1.daumcdn.net/cfile/tistory/99D20C355C94394109"
-                        alt="book image">
-                    <button type="button" class="like-button">256</button> <!--좋아요 버튼.(하트 이모티콘 넣어야함)--> 
-                    <div class="book-content">
-                        <h1>엔지니어를 위한 인문학 수업</h1>
-                        <h3>새뮤얼 플러먼</h3>
-                        <h3>2021.02.02</h3>
-                        <p>
+                    <div class="grid-view-content-img">
+                        <img src="https://t1.daumcdn.net/cfile/tistory/99D20C355C94394109"
+                            alt="book image">
+                    </div>
+                    <div class="grid-view-content-like">
+                        <img src="icon/like_white.svg">
+                        <span class="like-number">256</span> <!--좋아요 버튼.(하트 이모티콘 넣어야함)--> 
+                    </div>
+                    <div class="grid-book-info">
+                        <h1 class="grid-content-title">엔지니어도 인문학이 필요할까?</h1>
+                        <h3 class="grid-book-title">엔지니어를 위한 인문학 수업</h3>
+                        <p class="summary">
                             바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..
                         </p>
                     </div>
-                    <div class="content-info">
-                        <div class="profile-img"><!--작성자 옆 프로필사진-->
-                            <img src="#" alt="profile image">
+                    <div class="write-info">
+                        <div class="register-profile"><!--작성자 옆 프로필사진-->
+                            <img src="#">
+                            <span class="profile-nickname">Yunji Jeong</span>
                         </div>              
-                        <strong>Yunji Jeong</strong>
-                        <strong>2020.02.14</strong><!--작성일-->              
+                        <span class="register-date">2020.02.14</span><!--작성일-->              
                     </div>
                 </div>
                 <!--이하 반복-->
-            </div>
     
-            <div class="grid-view-contents">
                 <div class="grid-view-content">
-                    <img src="https://t1.daumcdn.net/cfile/tistory/99D20C355C94394109"
-                        alt="book image">
-                    <button type="button" class="like-button">256</button> <!--좋아요 버튼.(하트 이모티콘 넣어야함)--> 
-                    <div class="book-content">
-                        <h1>엔지니어를 위한 인문학 수업</h1>
-                        <h3>새뮤얼 플러먼</h3>
-                        <h3>2021.02.02</h3>
-                        <p>
+                    <div class="grid-view-content-img">
+                        <img src="https://t1.daumcdn.net/cfile/tistory/99D20C355C94394109"
+                            alt="book image">
+                    </div>
+                    <div class="grid-view-content-like">
+                        <img src="icon/like_white.svg">
+                        <span class="like-number">256</span> <!--좋아요 버튼.(하트 이모티콘 넣어야함)--> 
+                    </div>
+                    <div class="grid-book-info">
+                        <h1 class="grid-content-title">행복은 제 발로 걸어오지 않아. 그러니 내 발로 찾아가야지</h1>
+                        <h3 class="grid-book-title">또다시 같은 꿈을 꾸었어</h3>
+                        <p class="summary">
                             바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..
                         </p>
                     </div>
-                    <div class="content-info">
-                        <div class="profile-img"><!--작성자 옆 프로필사진-->
-                            <img src="#" alt="profile image">
+                    <div class="write-info">
+                        <div class="register-profile"><!--작성자 옆 프로필사진-->
+                            <img src="#">
+                            <span class="profile-nickname">Yunji Jeong</span>
                         </div>              
-                        <strong>Yunji Jeong</strong>
-                        <strong>2020.02.14</strong><!--작성일-->              
+                        <span class="register-date">2020.02.14</span><!--작성일-->              
                     </div>
                 </div>
-            </div>
     
-            <div class="grid-view-contents">
                 <div class="grid-view-content">
-                    <img src="https://t1.daumcdn.net/cfile/tistory/99D20C355C94394109"
-                        alt="book image">
-                    <button type="button" class="like-button">256</button> <!--좋아요 버튼.(하트 이모티콘 넣어야함)--> 
-                    <div class="book-content">
-                        <h1>엔지니어를 위한 인문학 수업</h1>
-                        <h3>새뮤얼 플러먼</h3>
-                        <h3>2021.02.02</h3>
-                        <p>
+                    <div class="grid-view-content-img">
+                        <img src="https://t1.daumcdn.net/cfile/tistory/99D20C355C94394109"
+                            alt="book image">
+                    </div>
+                    <div class="grid-view-content-like">
+                        <img src="icon/like_white.svg">
+                        <span class="like-number">256</span> <!--좋아요 버튼.(하트 이모티콘 넣어야함)--> 
+                    </div>
+                    <div class="grid-book-info">
+                        <h1 class="grid-content-title">엔지니어도 인문학이 필요할까?</h1>
+                        <h3 class="grid-book-title">엔지니어를 위한 인문학 수업</h3>
+                        <p class="summary">
                             바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..
                         </p>
                     </div>
-                    <div class="content-info">
-                        <div class="profile-img"><!--작성자 옆 프로필사진-->
-                            <img src="#" alt="profile image">
+                    <div class="write-info">
+                        <div class="register-profile"><!--작성자 옆 프로필사진-->
+                            <img src="#">
+                            <span class="profile-nickname">Yunji Jeong</span>
                         </div>              
-                        <strong>Yunji Jeong</strong>
-                        <strong>2020.02.14</strong><!--작성일-->              
+                        <span class="register-date">2020.02.14</span><!--작성일-->              
                     </div>
                 </div>
                 <!--이하 반복-->    
-            </div>
     
-            <div class="grid-view-contents">
                 <div class="grid-view-content">
-                    <img src="https://t1.daumcdn.net/cfile/tistory/99D20C355C94394109"
-                        alt="book image">
-                    <button type="button" class="like-button">256</button> <!--좋아요 버튼.(하트 이모티콘 넣어야함)--> 
-                    <div class="book-content">
-                        <h1>엔지니어를 위한 인문학 수업</h1>
-                        <h3>새뮤얼 플러먼</h3>
-                        <h3>2021.02.02</h3>
-                        <p>
+                    <div class="grid-view-content-img">
+                        <img src="https://t1.daumcdn.net/cfile/tistory/99D20C355C94394109"
+                            alt="book image">
+                    </div>
+                    <div class="grid-view-content-like">
+                        <img src="icon/like_white.svg">
+                        <span class="like-number">256</span> <!--좋아요 버튼.(하트 이모티콘 넣어야함)--> 
+                    </div>
+                    <div class="grid-book-info">
+                        <h1 class="grid-content-title">엔지니어도 인문학이 필요할까?</h1>
+                        <h3 class="grid-book-title">엔지니어를 위한 인문학 수업</h3>
+                        <p class="summary">
                             바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..
                         </p>
                     </div>
-                    <div class="content-info">
-                        <div class="profile-img"><!--작성자 옆 프로필사진-->
-                            <img src="#" alt="profile image">
+                    <div class="write-info">
+                        <div class="register-profile"><!--작성자 옆 프로필사진-->
+                            <img src="#">
+                            <span class="profile-nickname">Yunji Jeong</span>
                         </div>              
-                        <strong>Yunji Jeong</strong>
-                        <strong>2020.02.14</strong><!--작성일-->              
+                        <span class="register-date">2020.02.14</span><!--작성일-->              
+                    </div>
+                </div>
+                <!--이하 반복-->
+            
+                <div class="grid-view-content">
+                    <div class="grid-view-content-img">
+                        <img src="https://t1.daumcdn.net/cfile/tistory/99D20C355C94394109"
+                            alt="book image">
+                    </div>
+                    <div class="grid-view-content-like">
+                        <img src="icon/like_white.svg">
+                        <span class="like-number">256</span> <!--좋아요 버튼.(하트 이모티콘 넣어야함)--> 
+                    </div>
+                    <div class="grid-book-info">
+                        <h1 class="grid-content-title">엔지니어도 인문학이 필요할까?</h1>
+                        <h3 class="grid-book-title">엔지니어를 위한 인문학 수업</h3>
+                        <p class="summary">
+                            바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..
+                        </p>
+                    </div>
+                    <div class="write-info">
+                        <div class="register-profile"><!--작성자 옆 프로필사진-->
+                            <img src="#">
+                            <span class="profile-nickname">Yunji Jeong</span>
+                        </div>              
+                        <span class="register-date">2020.02.14</span><!--작성일-->              
                     </div>
                 </div>
                 <!--이하 반복-->
             </div>
-            
-            <div class="grid-view-contents">
-                <div class="grid-view-content">
-                    <img src="https://t1.daumcdn.net/cfile/tistory/99D20C355C94394109"
-                        alt="book image">
-                    <button type="button" class="like-button">256</button> <!--좋아요 버튼.(하트 이모티콘 넣어야함)--> 
-                    <div class="book-content">
-                        <h1>엔지니어를 위한 인문학 수업</h1>
-                        <h3>새뮤얼 플러먼</h3>
-                        <h3>2021.02.02</h3>
-                        <p>
-                            바야흐로 융합의 시대다. 공학과 인문학을 융합하는 교육은 엔지니어의 시야를 넓히고, 문제 해결의 새로운 실마리를 제공해 줄 것이다. 공학교 교육은..
-                        </p>
-                    </div>
-                    <div class="content-info">
-                        <div class="profile-img"><!--작성자 옆 프로필사진-->
-                            <img src="#" alt="profile image">
-                        </div>              
-                        <strong>Yunji Jeong</strong>
-                        <strong>2020.02.14</strong><!--작성일-->              
-                    </div>
+            <div id="list-view">
+                <div class="classification">
+                    <div class="classification-book-type">분야</div>
+                    <div class="classification-content-title">제목</div>
+                    <div class="classification-book-title">책 제목</div>
+                    <div class="classification-profile-nickname">작성자</div>
                 </div>
-                <!--이하 반복-->
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
+                <div class="list-view-content"></div>
             </div>
         </section>
     </div>


### PR DESCRIPTION
1. 그리드뷰와 리스트뷰 전환하는 부분
2. 그리드 뷰 : 글 제목 시작하는 부분과 책 제목 시작하는 부분 맞췄습니다. 그 외에도 그리드뷰 콘텐츠 넓이 조정하였고, 글 내용 45자까지 요약하여 출력하게 하였습니다.
3. 리스트 뷰 : 최대한 한 줄로 나오는 게 예쁠 것 같아서 글자 사이즈를 조금 줄였습니다. 제목이 길어져 두 줄로 넘어가는 부분까지 고려하여 높이도 조금 늘렸습니다.
4. 분야 선택 : 아직 수정해야 합니다. 선택했을 때 색이 변하기는 하는데 한 번 더 선택했을 때 원래 상태로 돌아오지 않습니다.